### PR TITLE
Update plex-media-server-0.9.12.3.ebuild

### DIFF
--- a/media-tv/plex-media-server/plex-media-server-0.9.12.3.ebuild
+++ b/media-tv/plex-media-server/plex-media-server-0.9.12.3.ebuild
@@ -7,7 +7,7 @@ EAPI="2"
 inherit eutils user systemd
 MAGIC1="1173"
 MAGIC2="937aac3"
-URI="http://nightlies.plexapp.com/directdl/plex-media-server/dist-ninja"
+URI="https://nightlies.plex.tv/directdl/plex-media-server/dist-ninja"
 DESCRIPTION="Plex Media Server is a free media library that is intended for use with a plex client available for OS X, iOS and Android systems. It is a standalone product which can be used in conjunction with every program, that knows the API. For managing the library a web based interface is provided."
 HOMEPAGE="http://www.plex.tv/"
 KEYWORDS="-* ~x86 ~amd64"


### PR DESCRIPTION
Plex redirects the link you use to an invalid resource, "https://nightlies.plex.tv/directdl....." (Note the extra . after tv)

I spoke with Moussekateer via IRC who directed me to the correct link above.